### PR TITLE
Add read / write functions for pci bus

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ ninjastorms_SOURCES = \
     kernel/interrupt_handler.S kernel/interrupt_handler.h \
     kernel/memory.h \
     kernel/mmio.c kernel/mmio.h \
+    kernel/pci/pci_mmio.c kernel/pci/pci_mmio.h \
     kernel/drivers/adc.c kernel/drivers/adc.h \
     kernel/drivers/button.c kernel/drivers/button.h \
     kernel/drivers/gpio.c kernel/drivers/gpio.h \

--- a/kernel/network/e1000.c
+++ b/kernel/network/e1000.c
@@ -9,30 +9,30 @@ e1000_device_t e1000 = {0};
 void
 writeCommand(uint16_t address, uint32_t value)
 {
-	pci_write32(e1000.mem_base+address, value);
+  pci_write32(e1000.mem_base+address, value);
 }
 
 uint32_t
 readCommand(uint16_t address)
 {
-	return pci_read32(e1000.mem_base+address);
+  return pci_read32(e1000.mem_base+address);
 }
 
 void
 detect_eeprom()
 {
-	// write 1 to REG_EEPROM
-	writeCommand(REG_EEPROM, 0x1);
+  // write 1 to REG_EEPROM
+  writeCommand(REG_EEPROM, 0x1);
 
-	uint32_t val = 0;
-	for(uint16_t i = 0; i < 1000 && ! e1000.eeprom_exists; i++)
-		{
-	    val = readCommand(REG_EEPROM);
-	    if(val & 0x10)
-	      e1000.eeprom_exists = 1;
-	    else
+  uint32_t val = 0;
+  for(uint16_t i = 0; i < 1000 && ! e1000.eeprom_exists; i++)
+    {
+      val = readCommand(REG_EEPROM);
+      if(val & 0x10)
+        e1000.eeprom_exists = 1;
+      else
         e1000.eeprom_exists = 0;
-		}
+    }
 #ifdef E1000_DEBUG
   printf("[E1000] eeprom exists: %x\n", e1000.eeprom_exists);
 #endif
@@ -43,19 +43,19 @@ read_mac()
 { 
   uint32_t mem_base_mac = e1000.mem_base + MAC_OFFSET;
   if(pci_read32(mem_base_mac) != 0)
-  	{
-  		printf("[E1000] MAC ");
+    {
+      printf("[E1000] MAC ");
       e1000.mac[0] = pci_read8(mem_base_mac);
       printf("%x", e1000.mac[0]);
-	    for(uint16_t i = 1; i < 6; i++)
-	    	{
-	        e1000.mac[i] = pci_read8(mem_base_mac + i);
-	        printf(":%x", e1000.mac[i]);
-	    	}
-    	printf("\n");
-  	}
+      for(uint16_t i = 1; i < 6; i++)
+        {
+          e1000.mac[i] = pci_read8(mem_base_mac + i);
+          printf(":%x", e1000.mac[i]);
+        }
+      printf("\n");
+    }
   else
-  	return 0;
+    return 0;
   return 1;
 }
 
@@ -79,26 +79,26 @@ rxinit()
 void
 e1000_start(void)
 {
-	detect_eeprom();
+  detect_eeprom();
   read_mac();
 }
 
 void
 e1000_init(void)
 {
-	printf("[E1000] Initializing driver.\n");
-	pci_device_t* e1000_pci_device = get_pci_device(INTEL_VEND, E1000_DEV);
-	
-	if(e1000_pci_device == (void*)0)
-		{
-			printf("[E1000] Network card not found!\n");
-			return;
-		}
-	printf("[E1000] Network card found!\n");
+  printf("[E1000] Initializing driver.\n");
+  pci_device_t* e1000_pci_device = get_pci_device(INTEL_VEND, E1000_DEV);
+  
+  if(e1000_pci_device == (void*)0)
+    {
+      printf("[E1000] Network card not found!\n");
+      return;
+    }
+  printf("[E1000] Network card found!\n");
 
-	e1000.mem_base = alloc_pci_memory(e1000_pci_device, 0);
-	e1000.io_base = alloc_pci_memory(e1000_pci_device, 1);
-	enable_bus_mastering(e1000_pci_device->config_base);
-	printf("[E1000] membase: 0x%x iobase: 0x%x\n", e1000.mem_base, e1000.io_base);
-	e1000_start();
+  e1000.mem_base = alloc_pci_memory(e1000_pci_device, 0);
+  e1000.io_base = alloc_pci_memory(e1000_pci_device, 1);
+  enable_bus_mastering(e1000_pci_device->config_base);
+  printf("[E1000] membase: 0x%x iobase: 0x%x\n", e1000.mem_base, e1000.io_base);
+  e1000_start();
 }

--- a/kernel/network/e1000.c
+++ b/kernel/network/e1000.c
@@ -2,20 +2,20 @@
 
 #include <stdio.h>
 #include "kernel/pci/pci.h"
-#include "kernel/mmio.h"
+#include "kernel/pci/pci_mmio.h"
 
 e1000_device_t e1000 = {0};
 
 void
 writeCommand(uint16_t address, uint32_t value)
 {
-	write32(e1000.mem_base+address, value);
+	pci_write32(e1000.mem_base+address, value);
 }
 
 uint32_t
 readCommand(uint16_t address)
 {
-	return read32(e1000.mem_base+address);
+	return pci_read32(e1000.mem_base+address);
 }
 
 void
@@ -42,14 +42,14 @@ uint8_t
 read_mac()
 { 
   uint32_t mem_base_mac = e1000.mem_base + MAC_OFFSET;
-  if(read32(mem_base_mac) != 0)
+  if(pci_read32(mem_base_mac) != 0)
   	{
   		printf("[E1000] MAC ");
-      e1000.mac[0] = read8(mem_base_mac);
+      e1000.mac[0] = pci_read8(mem_base_mac);
       printf("%x", e1000.mac[0]);
 	    for(uint16_t i = 1; i < 6; i++)
 	    	{
-	        e1000.mac[i] = read8(mem_base_mac + i);
+	        e1000.mac[i] = pci_read8(mem_base_mac + i);
 	        printf(":%x", e1000.mac[i]);
 	    	}
     	printf("\n");

--- a/kernel/pci/pci_mmio.c
+++ b/kernel/pci/pci_mmio.c
@@ -1,0 +1,147 @@
+
+/******************************************************************************
+ *       ninjastorms - shuriken operating system                              *
+ *                                                                            *
+ *    Copyright (C) 2013 - 2016  Andreas Grapentin et al.                     *
+ *                                                                            *
+ *    This program is free software: you can redistribute it and/or modify    *
+ *    it under the terms of the GNU General Public License as published by    *
+ *    the Free Software Foundation, either version 3 of the License, or       *
+ *    (at your option) any later version.                                     *
+ *                                                                            *
+ *    This program is distributed in the hope that it will be useful,         *
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ *    GNU General Public License for more details.                            *
+ *                                                                            *
+ *    You should have received a copy of the GNU General Public License       *
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.   *
+ ******************************************************************************/
+
+#include "pci_mmio.h"
+
+uint8_t
+pci_read8(uint32_t address)
+{
+  return (uint8_t) pci_read32(address);
+}
+
+uint16_t
+pci_read16(uint32_t address)
+{
+  return (uint16_t) pci_read32(address);
+}
+
+uint32_t
+pci_read32(uint32_t address)
+{
+  return *((volatile uint32_t*) address);
+}
+
+uint64_t
+pci_read64(uint32_t address)
+{
+  return *((volatile uint64_t*) address);
+}
+
+// works only if address % 4 == 0
+void
+write_word(uint32_t address, uint32_t value)
+{
+  *((volatile uint32_t*) address) = value;
+}
+
+void
+pci_write8(uint32_t address, uint8_t value)
+{
+  // write inside one word
+  uint8_t offset = address % 4;
+  uint32_t word_read = pci_read32(address - offset);
+  uint32_t word_write = value << offset * 8;
+  uint32_t mask = ~(0xFF << offset * 8);
+  uint32_t word = (word_read & mask) | word_write;
+  write_word(address - offset, word);
+}
+
+void
+pci_write16(uint32_t address, uint16_t value)
+{
+  uint8_t offset = address % 4;
+  if (offset != 3)
+    // write inside one word
+    {
+      uint32_t word_read = pci_read32(address - offset);
+      uint32_t word_write = value << offset * 8;
+      uint32_t mask = ~(0xFFFF << offset * 8);
+      uint32_t word = (word_read & mask) | word_write;
+      write_word(address - offset, word);
+    }
+  else
+    // write between two words
+    {
+      uint32_t lower_word_read = pci_read32(address - 3);
+      uint32_t lower_word_write = value << 24;
+      uint32_t lower_word = ((lower_word_read << 8) >> 8) | lower_word_write;
+      write_word(address - 3, lower_word);
+
+      uint32_t upper_word_read = pci_read32(address + 1);
+      uint32_t upper_word_write = value >> 8;
+      uint32_t upper_word = ((upper_word_read >> 8) << 8) | upper_word_write;
+      write_word(address + 1, upper_word);
+    }
+}
+
+void
+pci_write32(uint32_t address, uint32_t value)
+{
+  uint8_t lower_offset = address % 4;
+  if (lower_offset)
+    // write between two words
+    {
+      uint8_t upper_offset = 4 - lower_offset;
+
+      uint32_t lower_word_read = pci_read32(address - lower_offset);
+      uint32_t lower_word_write = value << lower_offset * 8;
+      uint32_t lower_word = ((lower_word_read << upper_offset * 8) >> upper_offset * 8) | lower_word_write;
+      write_word(address - lower_offset, lower_word);
+
+      uint32_t upper_word_read = pci_read32(address + upper_offset);
+      uint32_t upper_word_write = value >> upper_offset * 8;
+      uint32_t upper_word = ((upper_word_read >> lower_offset * 8) << lower_offset * 8) | upper_word_write;
+      write_word(address + upper_offset, upper_word);
+    }
+  else
+    // write exactly one word
+    write_word(address, value);
+}
+
+void
+pci_write64(uint32_t address, uint64_t value)
+{
+  uint8_t lower_offset = address % 4;
+  if (lower_offset)
+    // write between three words
+    {
+      uint8_t upper_offset = 4 - lower_offset;
+
+      uint32_t lower_word_read = pci_read32(address - lower_offset);
+      uint32_t lower_word_write = (uint32_t) (value << lower_offset * 8);
+      uint32_t lower_word = ((lower_word_read << upper_offset * 8) >> upper_offset * 8) | lower_word_write;
+      write_word(address - lower_offset, lower_word);
+
+      uint32_t middle_word_read = pci_read32(address + upper_offset);
+      uint32_t middle_word_write = (uint32_t) (value >> upper_offset * 8);
+      write_word(address + upper_offset, middle_word_write);
+
+      uint32_t upper_word_read = pci_read32(address + 4 + upper_offset);
+      uint32_t upper_word_write = (uint32_t) (value >> (upper_offset + 4) * 8);
+      uint32_t upper_word = ((upper_word_read >> lower_offset * 8) << lower_offset * 8) | upper_word_write;
+      write_word(address + 4 + upper_offset, upper_word);
+    }
+  else
+    // write exactly two words
+    {
+      write_word(address, (uint32_t) value);
+      write_word(address + 4, (uint32_t) (value >> 32)); 
+    }
+}

--- a/kernel/pci/pci_mmio.h
+++ b/kernel/pci/pci_mmio.h
@@ -18,52 +18,16 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.   *
  ******************************************************************************/
 
-#include "mmio.h"
+#pragma once
 
-uint8_t
-read8(uint32_t address)
-{
-	return *((volatile uint8_t*)(address));
-}
+#include <sys/types.h>
 
-uint16_t
-read16(uint32_t address)
-{
-	return *((volatile uint16_t*)(address));
-}
+uint8_t  pci_read8(uint32_t address);
+uint16_t pci_read16(uint32_t address);
+uint32_t pci_read32(uint32_t address);
+uint64_t pci_read64(uint32_t address);
 
-uint32_t
-read32(uint32_t address)
-{
-	return *((volatile uint32_t*)(address));
-}
-
-uint64_t
-read64(uint32_t address)
-{
-	return *((volatile uint64_t*)(address));
-}
-
-void
-write8(uint32_t address, uint8_t value)
-{
-	(*((volatile uint8_t*)(address)))=(value);
-}
-
-void
-write16(uint32_t address, uint16_t value)
-{
-	(*((volatile uint16_t*)(address)))=(value);
-}
-
-void
-write32(uint32_t address, uint32_t value)
-{
-	(*((volatile uint32_t*)(address)))=(value);
-}
-
-void
-write64(uint32_t address, uint64_t value)
-{
-	(*((volatile uint64_t*)(address)))=(value);
-}
+void pci_write8(uint32_t address, uint8_t value);
+void pci_write16(uint32_t address, uint16_t value);
+void pci_write32(uint32_t address, uint32_t value);
+void pci_write64(uint32_t address, uint64_t value);


### PR DESCRIPTION
You can test the pci write and read functions by inserting the following code in the  `read_mac` method in `e1000.c`:
```
for (uint32_t i = 0; i < 8; i++)
{
  uint8_t read = pci_read8(mem_base_mac + i);
  printf("read8 + %i: 0x%x\n", i, read);
}

for (uint32_t i = 0; i < 8; i++)
{
  uint16_t read = pci_read16(mem_base_mac + i);
  printf("read16 + %i: 0x%x\n", i, read);
}

for (uint32_t i = 0; i < 8; i++)
{
  uint32_t read = pci_read32(mem_base_mac + i);
  printf("read32 + %i: 0x%x\n", i, read);
}

for (uint32_t i = 0; i < 8; i++)
{
  uint64_t read = pci_read64(mem_base_mac + i);
  printf("read64 + %i: 0x%x %x\n", i, (uint32_t) (read >> 32), (uint32_t) read);
}

for (uint32_t i = 0; i < 5; i++)
{
  pci_write8(mem_base_mac + i, 0x11);
  uint64_t read = pci_read64(mem_base_mac);
  printf("write8 + %i: 0x%x %x\n", i, (uint32_t) (read >> 32), (uint32_t) read);
  pci_write64(mem_base_mac, 0x8000325476985452);
}

for (uint32_t i = 0; i < 5; i++)
{
  pci_write16(mem_base_mac + i, 0x1123);
  uint64_t read = pci_read64(mem_base_mac);
  printf("write16 + %i: 0x%x %x\n", i, (uint32_t) (read >> 32), (uint32_t) read);
  pci_write64(mem_base_mac, 0x8000325476985452);
}

for (uint32_t i = 0; i < 5; i++)
{
  pci_write32(mem_base_mac + i, 0x11234567);
  uint64_t read = pci_read64(mem_base_mac);
  printf("write32 + %i: 0x%x %x\n", i, (uint32_t) (read >> 32), (uint32_t) read);
  pci_write64(mem_base_mac, 0x8000325476985452);
}

for (uint32_t i = 0; i < 9; i++)
{
  pci_write64(mem_base_mac + i, 0x1123456789ABCDEF);
  uint64_t lower_read = pci_read64(mem_base_mac);
  uint64_t upper_read = pci_read64(mem_base_mac + 8);
  printf("write64 (lower) + %i: 0x%x %x\n", i, (uint32_t) (lower_read >> 32), (uint32_t) lower_read);
  printf("write64 (upper) + %i: 0x%x %x\n", i, (uint32_t) (upper_read >> 32), (uint32_t) upper_read);
  pci_write64(mem_base_mac, 0x8000325476985452);
}
```