### PR TITLE
Use uppercase makros for logger

### DIFF
--- a/kernel/logger/logger.h
+++ b/kernel/logger/logger.h
@@ -2,11 +2,11 @@
 
 #include <sys/types.h>
 
-#define log_debug(...) general_log(0, __FILE__, __VA_ARGS__);
-#define log_info(...) general_log(1, __FILE__, __VA_ARGS__);
-#define log_warn(...) general_log(2, __FILE__, __VA_ARGS__);
-#define log_error(...) general_log(3, __FILE__, __VA_ARGS__);
-#define log_fatal(...) general_log(4, __FILE__, __VA_ARGS__);
+#define LOG_DEBUG(...) general_log(0, __FILE__, __VA_ARGS__);
+#define LOG_INFO(...) general_log(1, __FILE__, __VA_ARGS__);
+#define LOG_WARN(...) general_log(2, __FILE__, __VA_ARGS__);
+#define LOG_ERROR(...) general_log(3, __FILE__, __VA_ARGS__);
+#define LOG_FATAL(...) general_log(4, __FILE__, __VA_ARGS__);
 
 void general_log(uint32_t severity, const char* file, const char* format, ...);
 

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -117,8 +117,6 @@ kernel_main (void)
   puts("  shuriken ready");
   puts(shuriken);
 
-  LOG_DEBUG("Logger initialized!")
-
   pci_init();
   init_e1000();
   init_time();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -117,7 +117,7 @@ kernel_main (void)
   puts("  shuriken ready");
   puts(shuriken);
 
-  log_debug("Logger initialized!");
+  LOG_DEBUG("Logger initialized!")
 
   pci_init();
   init_e1000();

--- a/kernel/network/arp.c
+++ b/kernel/network/arp.c
@@ -38,23 +38,23 @@ arp_receive(ethernet_frame_t *frame)
   if(ntohs(arp_frame->hardware_type) != HTYPE_ETHERNET || arp_frame->hardware_addr_len != ETH_MAC_ADDRESS_LENGTH)
     {
 #ifdef ARP_DEBUG
-      log_warn("Hardware type is not supported! (no ethernet) hwtype: %x addr_len: %x", arp_frame->hardware_type, arp_frame->hardware_addr_len)
+      LOG_WARN("Hardware type is not supported! (no ethernet) hwtype: %x addr_len: %x", arp_frame->hardware_type, arp_frame->hardware_addr_len)
 #endif
       return;
     }
   if(ntohs(arp_frame->protocol_type) != TYPE_IPv4 || arp_frame->protocol_addr_len != IPV4_ADDR_LEN)
     {
 #ifdef ARP_DEBUG
-      log_warn("Protocol type is not supported! (no ipv4)");
+      LOG_WARN("Protocol type is not supported! (no ipv4)")
 #endif
       return;
     }
 #ifdef ARP_DEBUG
-  log_debug("Found ARP packet:")
-  log_debug("Source HW: %s", mac_to_str(ntoh_mac(arp_frame->src_hardware_addr)))
-  log_debug("Source IP: %x", ntohl(arp_frame->src_ip_address))
-  log_debug("Destination HW: %s", mac_to_str(ntoh_mac(arp_frame->dest_hardware_addr)))
-  log_debug("Destination IP: %x", ntohl(arp_frame->dest_ip_address))
+  LOG_DEBUG("Found ARP packet:")
+  LOG_DEBUG("Source HW: %s", mac_to_str(ntoh_mac(arp_frame->src_hardware_addr)))
+  LOG_DEBUG("Source IP: %x", ntohl(arp_frame->src_ip_address))
+  LOG_DEBUG("Destination HW: %s", mac_to_str(ntoh_mac(arp_frame->dest_hardware_addr)))
+  LOG_DEBUG("Destination IP: %x", ntohl(arp_frame->dest_ip_address))
 #endif
 
   switch(ntohs(arp_frame->opcode))
@@ -79,7 +79,7 @@ arp_send_request(uint32_t ip)
     ip
   );
 #ifdef ARP_DEBUG
-  log_debug("Sending arp request for ip %x", ip)
+  LOG_DEBUG("Sending arp request for ip %x", ip)
 #endif
   send_ethernet(BROADCAST_MAC, TYPE_ARP, &arp_frame, sizeof(arp_frame_t));
 }
@@ -90,7 +90,7 @@ arp_handle_request(arp_frame_t *frame)
   if(ntohl(frame->dest_ip_address) == OWN_IPV4_ADDR)
     {
 #ifdef ARP_DEBUG
-      log_debug("I have been requested... let's answer.");
+      LOG_DEBUG("I have been requested... let's answer.")
 #endif
       arp_frame_t arp_frame = arp_build_frame(
         ARP_REPLY,

--- a/kernel/network/e1000.c
+++ b/kernel/network/e1000.c
@@ -64,7 +64,7 @@ detect_eeprom()
         e1000->eeprom_exists = 0;
     }
 #ifdef E1000_DEBUG
-  log_debug("eeprom exists: %x", e1000->eeprom_exists);
+  LOG_DEBUG("EEPROM exists: %x", e1000->eeprom_exists)
 #endif
 }
 
@@ -79,7 +79,7 @@ read_e1000_hardware_address()
       memcpy(&mac_network, &mac_data, 6);
       e1000->mac = ntoh_mac(mac_network);
 #ifdef E1000_DEBUG
-      log_debug("MAC: %s", mac_to_str(e1000->mac));
+      LOG_DEBUG("MAC: %s", mac_to_str(e1000->mac))
 #endif
     }
 }
@@ -173,7 +173,7 @@ send_packet(const void *p_data, uint16_t p_len)
 {
   if(!is_e1000_available()) return -1;
 #ifdef E1000_DEBUG
-  log_debug("Sending packet with len %i", p_len); 
+  LOG_DEBUG("Sending packet with len %i", p_len)
 #endif
   e1000_tx_desc_t *curr = &(e1000->tx_descs[e1000->tx_cur]);
   curr->addr = (uint32_t) p_data;
@@ -187,7 +187,7 @@ send_packet(const void *p_data, uint16_t p_len)
 
   while(!(curr->status));
 #ifdef E1000_DEBUG
-  log_debug("Packet send!"); 
+  LOG_DEBUG("Packet send!")
 #endif
   return 0;
 }
@@ -205,7 +205,7 @@ receive_packet()
       uint16_t len = e1000->rx_descs[e1000->rx_cur].length;
 
 #ifdef E1000_DEBUG
-      log_debug("received packet with length: %i", len)
+      LOG_DEBUG("Received packet with length: %i", len)
 #endif
 
       insert_packet(buf, len);
@@ -229,33 +229,29 @@ init_e1000(void)
   e1000 = (e1000_device_t*) malloc(sizeof(e1000_device_t));
   if(e1000 == NULL)
     {
-#ifdef E1000_DEBUG
-      log_warn("No memory for e1000 struct left!")
-#endif
+      LOG_ERROR("No memory for e1000 struct left!")
       return;
     }
 
 #ifdef E1000_DEBUG
-  log_debug("Initializing driver.")
+  LOG_DEBUG("Initializing driver.")
 #endif
   e1000->pci_device = get_pci_device(INTEL_VEND, E1000_DEV);
   
   if(!is_e1000_available())
     {
-#ifdef E1000_DEBUG
-      log_warn("Network card not found!")
-#endif
+      LOG_ERROR("Network card not found!")
       return;
     }
 #ifdef E1000_DEBUG
-  log_debug("Network card found!")
+  LOG_DEBUG("Network card found!")
 #endif
 
   e1000->mem_base = alloc_pci_memory(e1000->pci_device, 0);
   e1000->io_base = alloc_pci_memory(e1000->pci_device, 1);
   enable_bus_mastering(e1000->pci_device->config_base);
 #ifdef E1000_DEBUG
-  log_debug("membase: 0x%x iobase: 0x%x", e1000->mem_base, e1000->io_base)
+  LOG_DEBUG("Membase: 0x%x iobase: 0x%x", e1000->mem_base, e1000->io_base)
 #endif
   start_e1000();
 }

--- a/kernel/network/ethernet.c
+++ b/kernel/network/ethernet.c
@@ -43,7 +43,7 @@ send_ethernet(mac_address_t dest_mac, ether_type eth_type, void *payload, size_t
   memcpy(eth_frame->payload, payload, len);
 
 #ifdef ETHERNET_DEBUG
-  log_debug("Payload is %i, adding %i padding", len_payload, len_padding);
+  LOG_DEBUG("Payload is %i, adding %i padding", len_payload, len_padding)
 #endif
   if(len_padding != 0)
     {

--- a/kernel/network/ipv4.c
+++ b/kernel/network/ipv4.c
@@ -37,7 +37,7 @@ send_ipv4(uint32_t ip, void *payload, size_t len)
       if(clock_seconds() - start > WAIT_ON_ARP_TIMEOUT)
         {
 #ifdef IPV4_DEBUG
-          log_debug("Sending to IP %x timed out waiting for arp", ip)
+          LOG_DEBUG("Sending to IP %x timed out waiting for arp", ip)
 #endif
           return -1;
         }

--- a/kernel/network/network_task.c
+++ b/kernel/network/network_task.c
@@ -57,7 +57,7 @@ insert_packet (uint8_t *data, size_t len)
     }
   else
     {
-      log_warn("Packet Queue full!");
+      LOG_WARN("Packet Queue full!");
     }
 }
 

--- a/kernel/network/routing.c
+++ b/kernel/network/routing.c
@@ -70,7 +70,7 @@ add_arp_table_entry(mac_address_t mac, uint32_t ip) {
   arp_table[slot] = (arp_table_entry_t) {ip, mac, clock_seconds()};
 
 #ifdef ROUTING_DEBUG
-  log_debug("added ip %x in arp table at slot %i with time %i", ip, slot, (uint32_t)arp_table[slot].entry_time)
+  LOG_DEBUG("Added ip %x in arp table at slot %i with time %i", ip, slot, (uint32_t)arp_table[slot].entry_time)
 #endif
 }
 
@@ -81,7 +81,7 @@ update_arp_table(mac_address_t mac, uint32_t ip) {
     {
       arp_table[position].mac = mac;
 #ifdef ROUTING_DEBUG
-      log_debug("updated ip %x in arp table", ip)
+      LOG_DEBUG("Updated ip %x in arp table", ip)
 #endif
       return;
     }
@@ -100,7 +100,7 @@ arp_table_find(uint32_t ip)
         {
           // entry is too old, make it invalid
 #ifdef ROUTING_DEBUG
-          log_debug("entry at %i is too old with time %i", i, (uint32_t)arp_table[i].entry_time);
+          LOG_DEBUG("Entry at %i is too old with time %i", i, (uint32_t)arp_table[i].entry_time)
 #endif
           arp_table[i] = NULL_ENTRY;
         }
@@ -109,7 +109,7 @@ arp_table_find(uint32_t ip)
           res = i;
           arp_table[i].entry_time = clock_seconds();
 #ifdef ROUTING_DEBUG
-          log_debug("ip %x found in arp table at %i new time %i", ip, i, (uint32_t)arp_table[i].entry_time)
+          LOG_DEBUG("IP %x found in arp table at %i new time %i", ip, i, (uint32_t)arp_table[i].entry_time)
 #endif
         }
     }

--- a/kernel/pci/pci.c
+++ b/kernel/pci/pci.c
@@ -87,7 +87,9 @@ alloc_pci_memory(pci_device_t* device, uint8_t bar)
 void
 enumerate_pci_devices(void)
 {
-  printf("[Enumerating PCI devices]\n");
+#ifdef PCI_DEBUG
+  LOG_DEBUG("Enumerating PCI devices:")
+#endif
   for (int i = 11; i < 32; ++i)
   {
     uint32_t device_addr = (PCI_CONFIG + ((i) << PCI_DEVICE_BIT_OFFSET));
@@ -102,7 +104,9 @@ enumerate_pci_devices(void)
     device->vendor_id = vendor_id;
     device->device_id = device_id;
 
-    printf("[PCI] Device slot: %i at: 0x%x DeviceID: 0x%x VendorID: 0x%x\n", i, device_addr, vendor_id, device_id);
+#ifdef PCI_DEBUG
+    LOG_DEBUG("Device slot: %i at: 0x%x DeviceID: 0x%x VendorID: 0x%x", i, device_addr, vendor_id, device_id)
+#endif
   }
 }
 
@@ -128,7 +132,7 @@ board_configuration(void)
         }
     }
   if(slot == 0){
-    printf("[PCI] Cannot find PCI core!\n");
+    LOG_ERROR("Cannot find PCI core!")
     return -1;
   }
   uint32_t pci_config_base = PCI_CONFIG + (slot << PCI_DEVICE_BIT_OFFSET);
@@ -159,7 +163,9 @@ get_pci_device(uint16_t vendor_id, uint16_t device_id)
 void
 pci_init(void)
 {
-  printf("[PCI] Initiating\n");
+#ifdef PCI_DEBUG
+  LOG_DEBUG("Initiating PCI")
+#endif
   board_configuration();
   enumerate_pci_devices();
 }

--- a/kernel/pci/pci.h
+++ b/kernel/pci/pci.h
@@ -22,7 +22,7 @@
 
 #include <sys/types.h>
 
-#define PCI_DEBUG
+//#define PCI_DEBUG
 
 #define PCI_SELF_CONFIG 0x41000000
 #define PCI_CONFIG 0x42000000


### PR DESCRIPTION
Fixes #20 

This should be rebased on master after #23 was merged into it. After that the new logger statements from the arp branch must be adapted as well.